### PR TITLE
Enhancement: Add PHP 7.3 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 before_script:
   - composer self-update
   - composer install


### PR DESCRIPTION
This PR

* [x] adds PHP 7.3 to the Travis CI build matrix