### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
   - 7.2
   - 7.3
 before_script:
-  - composer self-update
   - composer install
 script:
   - vendor/bin/phing


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself twice on Travis