### PR TITLE
Enhancement: Run 'composer validate' and 'composer normalize' as part of build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,14 +2,28 @@
 <project name="PHPStan deprecation rules" default="check">
 
 	<target name="check" depends="
-		composer,
+		composer-validate,
+		composer-install,
 		lint,
 		cs,
+		composer-normalize-check,
 		tests,
 		phpstan
 	"/>
 
-	<target name="composer">
+	<target name="composer-validate">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="validate"/>
+			<arg value="--ansi"/>
+		</exec>
+	</target>
+
+	<target name="composer-install">
 		<exec
 				executable="composer"
 				logoutput="true"
@@ -17,6 +31,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
 	"name": "phpstan/phpstan-deprecation-rules",
+	"type": "phpstan-extension",
 	"description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
 	"license": [
 		"MIT"
 	],
-	"type": "phpstan-extension",
 	"require": {
 		"php": "~7.1",
 		"nikic/php-parser": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"consistence/coding-standard": "^3.0.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"jakub-onderka/php-parallel-lint": "^1.0",
+		"localheinz/composer-normalize": "^1.3.0",
 		"phing/phing": "^2.16.0",
 		"phpstan/phpstan-phpunit": "^0.12",
 		"phpunit/phpunit": "^7.0",


### PR DESCRIPTION
This PR

* [x] runs `composer validate` as well as `composer normalize` as part of the build
* [x] runs `composer normalize`