### PR TITLE
Enhancement: Use ergebnis/composer-normalize instead of localheinz/composer-normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 	"require-dev": {
 		"consistence/coding-standard": "^3.0.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+		"ergebnis/composer-normalize": "^2.0.2",
 		"jakub-onderka/php-parallel-lint": "^1.0",
-		"localheinz/composer-normalize": "^1.3.0",
 		"phing/phing": "^2.16.0",
 		"phpstan/phpstan-phpunit": "^0.12",
 		"phpunit/phpunit": "^7.0",


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/composer-normalize` instead of `localheinz/composer-normalize`

Related to https://github.com/ergebnis/composer-normalize/issues/266.

💁‍♂ For reference, see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis/.