### PR TITLE
Deprecated constants

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -9,6 +9,7 @@ rules:
 	- PHPStan\Rules\Deprecations\CallToDeprecatedMethodRule
 	- PHPStan\Rules\Deprecations\CallToDeprecatedStaticMethodRule
 	- PHPStan\Rules\Deprecations\FetchingClassConstOfDeprecatedClassRule
+	- PHPStan\Rules\Deprecations\FetchingDeprecatedConstRule
 	- PHPStan\Rules\Deprecations\ImplementationOfDeprecatedInterfaceRule
 	- PHPStan\Rules\Deprecations\InheritanceOfDeprecatedClassRule
 	- PHPStan\Rules\Deprecations\InheritanceOfDeprecatedInterfaceRule

--- a/src/Rules/Deprecations/FetchingDeprecatedConstRule.php
+++ b/src/Rules/Deprecations/FetchingDeprecatedConstRule.php
@@ -17,14 +17,17 @@ class FetchingDeprecatedConstRule implements \PHPStan\Rules\Rule
 	private $reflectionProvider;
 
 	/** @var array<string,string> */
-	private $deprecatedConstants = [
-		'FILTER_FLAG_SCHEME_REQUIRED' => 'Use of constant %s is deprecated since PHP 7.3.',
-		'FILTER_FLAG_HOST_REQUIRED' => 'Use of constant %s is deprecated since PHP 7.3.',
-	];
+	private $deprecatedConstants = [];
 
 	public function __construct(ReflectionProvider $reflectionProvider)
 	{
 		$this->reflectionProvider = $reflectionProvider;
+
+		// phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+		if (PHP_VERSION_ID >= 70300) {
+			$this->deprecatedConstants['FILTER_FLAG_SCHEME_REQUIRED'] = 'Use of constant %s is deprecated since PHP 7.3.';
+			$this->deprecatedConstants['FILTER_FLAG_HOST_REQUIRED'] = 'Use of constant %s is deprecated since PHP 7.3.';
+		}
 	}
 
 	public function getNodeType(): string

--- a/src/Rules/Deprecations/FetchingDeprecatedConstRule.php
+++ b/src/Rules/Deprecations/FetchingDeprecatedConstRule.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\GlobalConstantReflection;
+use PHPStan\Reflection\ReflectionProvider;
+
+/**
+ * @implements \PHPStan\Rules\Rule<ConstFetch>
+ */
+class FetchingDeprecatedConstRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var ReflectionProvider */
+	private $reflectionProvider;
+
+	/** @var array<string,string> */
+	private $deprecatedConstants = [
+		'FILTER_FLAG_SCHEME_REQUIRED' => 'Use of constant %s is deprecated since PHP 7.3.',
+		'FILTER_FLAG_HOST_REQUIRED' => 'Use of constant %s is deprecated since PHP 7.3.',
+	];
+
+	public function __construct(ReflectionProvider $reflectionProvider)
+	{
+		$this->reflectionProvider = $reflectionProvider;
+	}
+
+	public function getNodeType(): string
+	{
+		return ConstFetch::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (DeprecatedScopeHelper::isScopeDeprecated($scope)) {
+			return [];
+		}
+
+		if (!$this->reflectionProvider->hasConstant($node->name, $scope)) {
+			return [];
+		}
+
+		$constantReflection = $this->reflectionProvider->getConstant($node->name, $scope);
+
+		if ($this->isDeprecated($constantReflection)) {
+			return [sprintf(
+				$this->deprecatedConstants[$constantReflection->getName()] ?? 'Use of constant %s is deprecated.',
+				$constantReflection->getName()
+			)];
+		}
+
+		return [];
+	}
+
+	private function isDeprecated(GlobalConstantReflection $constantReflection): bool
+	{
+		return $constantReflection->isDeprecated()->yes()
+			|| isset($this->deprecatedConstants[$constantReflection->getName()]);
+	}
+
+}

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -19,35 +19,39 @@ class FetchingDeprecatedConstRuleTest extends \PHPStan\Testing\RuleTestCase
 			$this->markTestSkipped('Required constants are not available, PHP≥8?');
 		}
 
+		$expectedErrors = [];
+
+		if (PHP_VERSION_ID >= 70300) {
+			$expectedErrors[] = [
+				'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
+				5,
+			];
+			$expectedErrors[] = [
+				'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
+				6,
+			];
+			$expectedErrors[] = [
+				'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
+				7,
+			];
+			$expectedErrors[] = [
+				'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
+				8,
+			];
+			$expectedErrors[] = [
+				'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
+				37,
+			];
+			$expectedErrors[] = [
+				'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
+				38,
+			];
+		}
+
 		require_once __DIR__ . '/data/fetching-deprecated-const-definition.php';
 		$this->analyse(
 			[__DIR__ . '/data/fetching-deprecated-const.php'],
-			[
-				[
-					'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
-					5,
-				],
-				[
-					'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
-					6,
-				],
-				[
-					'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
-					7,
-				],
-				[
-					'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
-					8,
-				],
-				[
-					'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
-					37,
-				],
-				[
-					'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
-					38,
-				],
-			]
+			$expectedErrors
 		);
 	}
 

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<FetchingDeprecatedConstRule>
+ */
+class FetchingDeprecatedConstRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new FetchingDeprecatedConstRule($this->createReflectionProvider());
+	}
+
+	public function testFetchingDeprecatedConst(): void
+	{
+		if (!defined('FILTER_FLAG_SCHEME_REQUIRED') || !defined('FILTER_FLAG_HOST_REQUIRED')) {
+			$this->markTestSkipped('Required constants are not available, PHP≥8?');
+		}
+
+		require_once __DIR__ . '/data/fetching-deprecated-const-definition.php';
+		$this->analyse(
+			[__DIR__ . '/data/fetching-deprecated-const.php'],
+			[
+				[
+					'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
+					5,
+				],
+				[
+					'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
+					6,
+				],
+				[
+					'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
+					7,
+				],
+				[
+					'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
+					8,
+				],
+				[
+					'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated since PHP 7.3.',
+					37,
+				],
+				[
+					'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated since PHP 7.3.',
+					38,
+				],
+			]
+		);
+	}
+
+}

--- a/tests/Rules/Deprecations/data/fetching-deprecated-const-definition.php
+++ b/tests/Rules/Deprecations/data/fetching-deprecated-const-definition.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FetchingDeprecatedConst\Redefined {
+
+	const FILTER_FLAG_SCHEME_REQUIRED = 'foo2';
+	const FILTER_FLAG_HOST_REQUIRED = 'bar2';
+
+}

--- a/tests/Rules/Deprecations/data/fetching-deprecated-const.php
+++ b/tests/Rules/Deprecations/data/fetching-deprecated-const.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FetchingDeprecatedConst {
+
+	\FILTER_FLAG_SCHEME_REQUIRED;
+	\FILTER_FLAG_HOST_REQUIRED;
+	FILTER_FLAG_SCHEME_REQUIRED;
+	FILTER_FLAG_HOST_REQUIRED;
+
+	/**
+	 * @deprecated
+	 */
+	function deprecated_scope()
+	{
+		\FILTER_FLAG_SCHEME_REQUIRED;
+		\FILTER_FLAG_HOST_REQUIRED;
+	}
+
+	/**
+	 * @deprecated nothing to see
+	 */
+	class deprecated_scope2
+	{
+
+		public function test()
+		{
+			\FILTER_FLAG_SCHEME_REQUIRED;
+			\FILTER_FLAG_HOST_REQUIRED;
+		}
+
+	}
+
+}
+
+namespace FetchingDeprecatedConst\Redefined {
+
+	\FILTER_FLAG_SCHEME_REQUIRED;
+	\FILTER_FLAG_HOST_REQUIRED;
+	FILTER_FLAG_SCHEME_REQUIRED; // ok
+	FILTER_FLAG_HOST_REQUIRED; // ok
+
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan-deprecation-rules/issues/18

How is this? I couldn't really find anything comparable to base this rule off with regards to the definition of the deprecated constants.