### PR TITLE
Add a UsageOfDeprecatedCastRule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -17,4 +17,5 @@ rules:
 	- PHPStan\Rules\Deprecations\TypeHintDeprecatedInClassMethodSignatureRule
 	- PHPStan\Rules\Deprecations\TypeHintDeprecatedInClosureSignatureRule
 	- PHPStan\Rules\Deprecations\TypeHintDeprecatedInFunctionSignatureRule
+	- PHPStan\Rules\Deprecations\UsageOfDeprecatedCastRule
 	- PHPStan\Rules\Deprecations\UsageOfDeprecatedTraitRule

--- a/src/Rules/Deprecations/UsageOfDeprecatedCastRule.php
+++ b/src/Rules/Deprecations/UsageOfDeprecatedCastRule.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Cast;
+use PHPStan\Analyser\Scope;
+use function sprintf;
+
+/**
+ * @implements \PHPStan\Rules\Rule<Cast>
+ */
+class UsageOfDeprecatedCastRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Cast::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (DeprecatedScopeHelper::isScopeDeprecated($scope)) {
+			return [];
+		}
+
+		$castedType = $scope->getType($node->expr);
+		if (! $castedType->hasMethod('__toString')->yes()) {
+			return [];
+		}
+		$method = $castedType->getMethod('__toString', $scope);
+
+		if (! $method->isDeprecated()->yes()) {
+			return [];
+		}
+		$description = $method->getDeprecatedDescription();
+		if ($description === null) {
+			return [sprintf(
+				'Casting class %s to string is deprecated.',
+				$method->getDeclaringClass()->getName()
+			)];
+		}
+
+		return [sprintf(
+			"Casting class %s to string is deprecated.:\n%s",
+			$method->getDeclaringClass()->getName(),
+			$description
+		)];
+	}
+
+}

--- a/tests/Rules/Deprecations/UsageOfDeprecatedCastRuleTest.php
+++ b/tests/Rules/Deprecations/UsageOfDeprecatedCastRuleTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<UsageOfDeprecatedCastRule>
+ */
+class UsageOfDeprecatedCastRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new UsageOfDeprecatedCastRule();
+	}
+
+	public function testUsageOfDeprecatedTrait(): void
+	{
+		require_once __DIR__ . '/data/usage-of-deprecated-cast.php';
+		$this->analyse(
+			[__DIR__ . '/data/usage-of-deprecated-cast.php'],
+			[
+				[
+					'Casting class UsageOfDeprecatedCast\Foo to string is deprecated.',
+					17,
+				],
+			]
+		);
+	}
+
+}

--- a/tests/Rules/Deprecations/data/usage-of-deprecated-cast.php
+++ b/tests/Rules/Deprecations/data/usage-of-deprecated-cast.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace UsageOfDeprecatedCast;
+
+class Foo
+{
+	/**
+	 * @deprecated
+	 */
+	public function __toString()
+	{
+		return 'foo';
+	}
+}
+
+function foo(Foo $foo): string {
+	return (string) $foo;
+}
+
+/**
+ * @deprecated
+ */
+function deprecatedScope(Foo $foo): string
+{
+	return (string) $foo;
+}


### PR DESCRIPTION
I ran into this with the deprecation of casting ReflectionType to string. This package did not pick up on that, and now it does.