### PR TITLE
Failing test case - Usage of deprecated constant via subclass is not marked as deprecation call

### DIFF
--- a/tests/Rules/Deprecations/FetchingClassConstOfDeprecatedClassRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingClassConstOfDeprecatedClassRuleTest.php
@@ -48,6 +48,14 @@ class FetchingClassConstOfDeprecatedClassRuleTest extends \PHPStan\Testing\RuleT
 					"Fetching class constant FOO of deprecated class FetchingClassConstOfDeprecatedClass\DeprecatedBar:\nDeprecated for some reason.",
 					14,
 				],
+				[
+					"Fetching deprecated class constant DEPRECATED_FOO of class FetchingClassConstOfDeprecatedClass\SubFoo.",
+					16,
+				],
+				[
+					"Fetching deprecated class constant DEPRECATED_WITH_DESCRIPTION of class FetchingClassConstOfDeprecatedClass\SubFoo:\nUse different constant.",
+					17,
+				],
 			]
 		);
 	}

--- a/tests/Rules/Deprecations/data/fetching-class-const-of-deprecated-class.php
+++ b/tests/Rules/Deprecations/data/fetching-class-const-of-deprecated-class.php
@@ -13,6 +13,9 @@ DeprecatedFoo::class;
 Foo::DEPRECATED_WITH_DESCRIPTION;
 DeprecatedBar::FOO;
 
+SubFoo::DEPRECATED_FOO;
+SubFoo::DEPRECATED_WITH_DESCRIPTION;
+
 /**
  * @deprecated
  */
@@ -33,5 +36,10 @@ class DeprecatedScope
 		Foo::class;
 		DeprecatedFoo::class;
 	}
+
+}
+
+class SubFoo extends Foo
+{
 
 }


### PR DESCRIPTION
The same problem is with deprecated constant defined in interface and used via subclass.

See e.g. https://github.com/nette/application/blob/v2.4/src/Application/IRouter.php#L22 used with SimpleRouter:

Code `\Nette\Application\Routers\SimpleRouter::SECURED` throws no error