### PR TITLE
support deprecated magic __toString() in echo statement

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -1,6 +1,8 @@
 services:
     -
         class: PHPStan\Rules\Deprecations\DeprecatedClassHelper
+    -
+        class: PHPStan\Rules\Deprecations\EchoDeprecatedBinaryOpToStringRule
 
 rules:
 	- PHPStan\Rules\Deprecations\AccessDeprecatedPropertyRule
@@ -19,3 +21,7 @@ rules:
 	- PHPStan\Rules\Deprecations\TypeHintDeprecatedInFunctionSignatureRule
 	- PHPStan\Rules\Deprecations\UsageOfDeprecatedCastRule
 	- PHPStan\Rules\Deprecations\UsageOfDeprecatedTraitRule
+
+conditionalTags:
+	PHPStan\Rules\Deprecations\EchoDeprecatedBinaryOpToStringRule:
+		phpstan.rules.rule: %featureToggles.bleedingEdge%

--- a/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Echo_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use function PHPStan\dumpType;
+
+/**
+ * @implements \PHPStan\Rules\Rule<Echo_>
+ */
+class EchoDeprecatedBinaryOpToStringRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var RuleLevelHelper */
+	private $ruleLevelHelper;
+
+	public function __construct(RuleLevelHelper $ruleLevelHelper)
+	{
+		$this->ruleLevelHelper = $ruleLevelHelper;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\BinaryOp::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (DeprecatedScopeHelper::isScopeDeprecated($scope)) {
+			return [];
+		}
+
+		$messages = [];
+		$message = $this->checkExpr($node->left, $scope);
+		if ($message) {
+			$messages[] = $message;
+		}
+		$message = $this->checkExpr($node->right, $scope);
+		if ($message) {
+			$messages[] = $message;
+		}
+
+		return $messages;
+	}
+
+	private function checkExpr(Node\Expr $expr, Scope $scope): ?string
+	{
+		$type = $this->ruleLevelHelper->findTypeToCheck(
+			$scope,
+			$expr,
+			'',
+			static function (Type $type): bool {
+				return !$type->toString() instanceof ErrorType;
+			}
+		)->getType();
+
+		if (!$type instanceof ObjectType) {
+			return null;
+		}
+
+		$classReflection = $type->getClassReflection();
+
+		if ($classReflection === null) {
+			return null;
+		}
+
+		$methodReflection = $classReflection->getNativeMethod('__toString');
+
+		if (!$methodReflection->isDeprecated()->yes()) {
+			return null;
+		}
+
+		$description = $methodReflection->getDeprecatedDescription();
+		if ($description === null) {
+			return sprintf(
+				'Call to deprecated method %s() of class %s.',
+				$methodReflection->getName(),
+				$methodReflection->getDeclaringClass()->getName()
+			);
+		}
+
+		return sprintf(
+			"Call to deprecated method %s() of class %s:\n%s",
+			$methodReflection->getName(),
+			$methodReflection->getDeclaringClass()->getName(),
+			$description
+		);
+	}
+
+}

--- a/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
@@ -13,6 +13,7 @@ use PHPStan\Type\TypeUtils;
  */
 class EchoDeprecatedBinaryOpToStringRule implements \PHPStan\Rules\Rule
 {
+
 	/** @var Broker */
 	private $broker;
 
@@ -87,4 +88,5 @@ class EchoDeprecatedBinaryOpToStringRule implements \PHPStan\Rules\Rule
 
 		return null;
 	}
+
 }

--- a/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
@@ -9,7 +9,7 @@ use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\TypeUtils;
 
 /**
- * @implements \PHPStan\Rules\Rule<Echo_>
+ * @implements \PHPStan\Rules\Rule<BinaryOp>
  */
 class EchoDeprecatedBinaryOpToStringRule implements \PHPStan\Rules\Rule
 {
@@ -17,13 +17,9 @@ class EchoDeprecatedBinaryOpToStringRule implements \PHPStan\Rules\Rule
 	/** @var Broker */
 	private $broker;
 
-	/** @var RuleLevelHelper */
-	private $ruleLevelHelper;
-
-	public function __construct(Broker $broker, RuleLevelHelper $ruleLevelHelper)
+	public function __construct(Broker $broker)
 	{
 		$this->broker = $broker;
-		$this->ruleLevelHelper = $ruleLevelHelper;
 	}
 
 	public function getNodeType(): string

--- a/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRule.php
@@ -3,9 +3,9 @@
 namespace PHPStan\Rules\Deprecations;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
-use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\TypeUtils;
 
 /**
@@ -24,7 +24,7 @@ class EchoDeprecatedBinaryOpToStringRule implements \PHPStan\Rules\Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Expr\BinaryOp::class;
+		return BinaryOp::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -63,7 +63,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 				continue;
 			}
 
-			$methodReflection = $classReflection->getNativeMethod('__toString', $scope);
+			$methodReflection = $classReflection->getNativeMethod('__toString');
 
 			if (!$methodReflection->isDeprecated()->yes()) {
 				continue;

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -36,28 +36,34 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 		}
 
 		$messages = [];
-
 		foreach ($node->exprs as $key => $expr) {
-			if ($expr instanceof Node\Expr\Variable) {
-				$message = $this->checkExpr($expr, $scope);
-
-				if ($message) {
-					$messages[] = $message;
-				}
-			} elseif ($expr instanceof Node\Expr\BinaryOp\Concat) {
-				$message = $this->checkExpr($expr->left, $scope);
-				if ($message) {
-					$messages[] = $message;
-				}
-
-				$message = $this->checkExpr($expr->right, $scope);
-				if ($message) {
-					$messages[] = $message;
-				}
-			}
+			$this->deepCheckExpr($expr, $scope, $messages);
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * @param string[] $messages
+	 *
+	 * @return void
+	 */
+	private function deepCheckExpr(Node\Expr $expr, Scope $scope, array &$messages)
+	{
+		if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+			$this->deepCheckExpr($expr->left, $scope, $messages);
+			$this->deepCheckExpr($expr->right, $scope, $messages);
+		} elseif ($expr instanceof Node\Expr) {
+			$message = $this->checkExpr($expr, $scope);
+
+			if ($message) {
+				$messages[] = $message;
+			}
+		} else {
+
+
+
+		}
 	}
 
 	private function checkExpr(Node\Expr $expr, Scope $scope): ?string

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -50,7 +50,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 	 */
 	private function deepCheckExpr(Node\Expr $expr, Scope $scope, array &$messages): void
 	{
-		if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+		if ($expr instanceof Node\Expr\BinaryOp) {
 			$this->deepCheckExpr($expr->left, $scope, $messages);
 			$this->deepCheckExpr($expr->right, $scope, $messages);
 		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign || $expr instanceof Node\Expr\AssignOp) {

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -58,6 +58,11 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 			}
 
 			$classReflection = $type->getClassReflection();
+
+			if (null === $classReflection) {
+				continue;
+			}
+
 			$methodReflection = $classReflection->getNativeMethod('__toString', $scope);
 
 			if (!$methodReflection->isDeprecated()->yes()) {

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -53,7 +53,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 		if ($expr instanceof Node\Expr\BinaryOp\Concat) {
 			$this->deepCheckExpr($expr->left, $scope, $messages);
 			$this->deepCheckExpr($expr->right, $scope, $messages);
-		} elseif ($expr instanceof Node\Expr\Cast\String_) {
+		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign) {
 			$this->deepCheckExpr($expr->expr, $scope, $messages);
 		} elseif ($expr instanceof Node\Expr) {
 			$message = $this->checkExpr($expr, $scope);

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -3,19 +3,12 @@
 namespace PHPStan\Rules\Deprecations;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\PropertyFetch;
-use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
-use PHPStan\Analyser\VariableTypeHolder;
-use PHPStan\Broker\Broker;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\TypeUtils;
-use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
-use PHPStan\Type\VerbosityLevel;
+use PhpParser\Node\Stmt\Echo_;
 
 /**
  * @implements \PHPStan\Rules\Rule<Echo_>
@@ -35,7 +28,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Stmt\Echo_::class;
+		return Echo_::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -55,6 +55,10 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 			$this->deepCheckExpr($expr->right, $scope, $messages);
 		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign || $expr instanceof Node\Expr\AssignOp) {
 			$this->deepCheckExpr($expr->expr, $scope, $messages);
+		} elseif ($expr instanceof Node\Scalar\Encapsed) {
+			foreach($expr->parts as $part) {
+				$this->deepCheckExpr($part, $scope, $messages);
+			}
 		} else {
 			$message = $this->checkExpr($expr, $scope);
 

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\VariableTypeHolder;
+use PHPStan\Broker\Broker;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeUtils;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements \PHPStan\Rules\Rule<Echo_>
+ */
+class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
+{
+
+	/**
+	 * @var RuleLevelHelper
+	 */
+	private $ruleLevelHelper;
+
+	public function __construct(RuleLevelHelper $ruleLevelHelper)
+	{
+		$this->ruleLevelHelper = $ruleLevelHelper;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\Echo_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (DeprecatedScopeHelper::isScopeDeprecated($scope)) {
+			return [];
+		}
+
+		$messages = [];
+
+		foreach ($node->exprs as $key => $expr) {
+			if (!$expr instanceof Node\Expr\Variable) {
+				continue;
+			}
+
+			$type = $this->ruleLevelHelper->findTypeToCheck(
+				$scope,
+				$expr,
+				'',
+				static function (Type $type): bool {
+					return !$type->toString() instanceof ErrorType;
+				}
+			)->getType();
+
+			if (!$type instanceof ObjectType) {
+				continue;
+			}
+
+			$classReflection = $type->getClassReflection();
+			$methodReflection = $classReflection->getNativeMethod('__toString', $scope);
+
+			if (!$methodReflection->isDeprecated()->yes()) {
+				continue;
+			}
+
+			$description = $methodReflection->getDeprecatedDescription();
+			if ($description === null) {
+				$messages[] = sprintf(
+					'Call to deprecated method %s() of class %s.',
+					$methodReflection->getName(),
+					$methodReflection->getDeclaringClass()->getName()
+				);
+			} else {
+				$messages[] = sprintf(
+					"Call to deprecated method %s() of class %s:\n%s",
+					$methodReflection->getName(),
+					$methodReflection->getDeclaringClass()->getName(),
+					$description
+				);
+			}
+		}
+
+		return $messages;
+	}
+
+}

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -53,7 +53,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 		if ($expr instanceof Node\Expr\BinaryOp\Concat) {
 			$this->deepCheckExpr($expr->left, $scope, $messages);
 			$this->deepCheckExpr($expr->right, $scope, $messages);
-		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign) {
+		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign || $expr instanceof Node\Expr\AssignOp) {
 			$this->deepCheckExpr($expr->expr, $scope, $messages);
 		} elseif ($expr instanceof Node\Expr) {
 			$message = $this->checkExpr($expr, $scope);

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -53,6 +53,8 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 		if ($expr instanceof Node\Expr\BinaryOp\Concat) {
 			$this->deepCheckExpr($expr->left, $scope, $messages);
 			$this->deepCheckExpr($expr->right, $scope, $messages);
+		} elseif ($expr instanceof Node\Expr\Cast\String_) {
+			$this->deepCheckExpr($expr->expr, $scope, $messages);
 		} elseif ($expr instanceof Node\Expr) {
 			$message = $this->checkExpr($expr, $scope);
 

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -56,7 +56,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign || $expr instanceof Node\Expr\AssignOp) {
 			$this->deepCheckExpr($expr->expr, $scope, $messages);
 		} elseif ($expr instanceof Node\Scalar\Encapsed) {
-			foreach($expr->parts as $part) {
+			foreach ($expr->parts as $part) {
 				$this->deepCheckExpr($part, $scope, $messages);
 			}
 		} else {

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -60,7 +60,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 		return $messages;
 	}
 
-	private function checkExpr(Node $expr, Scope $scope): ?string
+	private function checkExpr(Node\Expr $expr, Scope $scope): ?string
 	{
 		$type = $this->ruleLevelHelper->findTypeToCheck(
 			$scope,

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -55,7 +55,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 			$this->deepCheckExpr($expr->right, $scope, $messages);
 		} elseif ($expr instanceof Node\Expr\Cast\String_ || $expr instanceof Node\Expr\Assign || $expr instanceof Node\Expr\AssignOp) {
 			$this->deepCheckExpr($expr->expr, $scope, $messages);
-		} elseif ($expr instanceof Node\Expr) {
+		} else {
 			$message = $this->checkExpr($expr, $scope);
 
 			if ($message) {

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -45,10 +45,8 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 
 	/**
 	 * @param string[] $messages
-	 *
-	 * @return void
 	 */
-	private function deepCheckExpr(Node\Expr $expr, Scope $scope, array &$messages)
+	private function deepCheckExpr(Node\Expr $expr, Scope $scope, array &$messages): void
 	{
 		if ($expr instanceof Node\Expr\BinaryOp\Concat) {
 			$this->deepCheckExpr($expr->left, $scope, $messages);
@@ -60,8 +58,6 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 				$messages[] = $message;
 			}
 		} else {
-
-
 
 		}
 	}

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -3,12 +3,12 @@
 namespace PHPStan\Rules\Deprecations;
 
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Echo_;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\ObjectType;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PhpParser\Node\Stmt\Echo_;
 
 /**
  * @implements \PHPStan\Rules\Rule<Echo_>
@@ -16,9 +16,7 @@ use PhpParser\Node\Stmt\Echo_;
 class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 {
 
-	/**
-	 * @var RuleLevelHelper
-	 */
+	/** @var RuleLevelHelper */
 	private $ruleLevelHelper;
 
 	public function __construct(RuleLevelHelper $ruleLevelHelper)
@@ -59,7 +57,7 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 
 			$classReflection = $type->getClassReflection();
 
-			if (null === $classReflection) {
+			if ($classReflection === null) {
 				continue;
 			}
 

--- a/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
+++ b/src/Rules/Deprecations/EchoDeprecatedToStringRule.php
@@ -44,6 +44,8 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 	}
 
 	/**
+	 * @param Node\Expr $expr
+	 * @param Scope $scope
 	 * @param string[] $messages
 	 */
 	private function deepCheckExpr(Node\Expr $expr, Scope $scope, array &$messages): void
@@ -57,8 +59,6 @@ class EchoDeprecatedToStringRule implements \PHPStan\Rules\Rule
 			if ($message) {
 				$messages[] = $message;
 			}
-		} else {
-
 		}
 	}
 

--- a/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
@@ -12,9 +12,7 @@ class EchoDeprecatedBinaryOpToStringRuleTest extends \PHPStan\Testing\RuleTestCa
 
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		$ruleLevelHelper = new RuleLevelHelper($this->createBroker(), true, false, true);
-
-		return new EchoDeprecatedBinaryOpToStringRule($this->createBroker(), $ruleLevelHelper);
+		return new EchoDeprecatedBinaryOpToStringRule($this->createBroker());
 	}
 
 	public function testDeprecatedMagicMethodToStringCall(): void

--- a/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+use PHPStan\Rules\RuleLevelHelper;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<EchoDeprecatedToStringRule>
+ */
+class EchoDeprecatedBinaryOpToStringRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		$ruleLevelHelper = new RuleLevelHelper($this->createBroker(), true, false, true);
+
+		return new EchoDeprecatedBinaryOpToStringRule($ruleLevelHelper);
+	}
+
+	public function testDeprecatedMagicMethodToStringCall(): void
+	{
+		require_once __DIR__ . '/data/echo-deprecated-binaryop-magic-method-tostring.php';
+		$this->analyse(
+			[__DIR__ . '/data/echo-deprecated-binaryop-magic-method-tostring.php'],
+			[
+				[
+					'Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBar.',
+					8,
+				],
+				[
+					'Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBar.',
+					9,
+				],
+				[
+					'Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBar.',
+					10,
+				],
+				[
+					'Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBar.',
+					11,
+				],
+				[
+					'Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBar.',
+					12,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					15,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					16,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					17,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					18,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedBinaryOpToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					19,
+				],
+			]
+		);
+	}
+
+}

--- a/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Rules\Deprecations;
 use PHPStan\Rules\RuleLevelHelper;
 
 /**
- * @extends \PHPStan\Testing\RuleTestCase<EchoDeprecatedToStringRule>
+ * @extends \PHPStan\Testing\RuleTestCase<EchoDeprecatedBinaryOpToStringRule>
  */
 class EchoDeprecatedBinaryOpToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 {

--- a/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
@@ -14,7 +14,7 @@ class EchoDeprecatedBinaryOpToStringRuleTest extends \PHPStan\Testing\RuleTestCa
 	{
 		$ruleLevelHelper = new RuleLevelHelper($this->createBroker(), true, false, true);
 
-		return new EchoDeprecatedBinaryOpToStringRule($ruleLevelHelper);
+		return new EchoDeprecatedBinaryOpToStringRule($this->createBroker(), $ruleLevelHelper);
 	}
 
 	public function testDeprecatedMagicMethodToStringCall(): void

--- a/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedBinaryOpToStringRuleTest.php
@@ -2,8 +2,6 @@
 
 namespace PHPStan\Rules\Deprecations;
 
-use PHPStan\Rules\RuleLevelHelper;
-
 /**
  * @extends \PHPStan\Testing\RuleTestCase<EchoDeprecatedBinaryOpToStringRule>
  */

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -56,8 +56,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					15,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					18,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					16,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -86,6 +86,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					25,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					26,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					27,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -72,8 +72,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					19,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					22,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					20,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -118,6 +118,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					33,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					34,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					35,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -26,7 +26,7 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
 					8,
-				]
+				],
 			]
 		);
 	}

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -52,8 +52,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					14,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					17,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					15,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -78,6 +78,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					23,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					24,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					25,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -44,8 +44,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					12,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					15,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					13,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -62,6 +62,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					19,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					20,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					21,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -31,6 +31,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
 					9,
 				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					12,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					13,
+				],
 			]
 		);
 	}

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -60,8 +60,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					16,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					19,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					17,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -94,6 +94,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					27,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					28,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					29,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -40,8 +40,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					11,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					14,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					12,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -54,6 +54,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					17,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					18,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					19,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -25,7 +25,7 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				[
 					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
-					6,
+					8,
 				]
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -76,8 +76,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					20,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					23,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					21,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -126,6 +126,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					35,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					36,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					37,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -64,8 +64,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					17,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					20,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					18,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -102,6 +102,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					29,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					30,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					31,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Deprecations;
+
+use PHPStan\Rules\RuleLevelHelper;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<EchoDeprecatedToStringRule>
+ */
+class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		$ruleLevelHelper = new RuleLevelHelper($this->createBroker(), true, false, true);
+
+		return new EchoDeprecatedToStringRule($ruleLevelHelper);
+	}
+
+	public function testDeprecatedMagicMethodToStringCall(): void
+	{
+		require_once __DIR__ . '/data/echo-deprecated-magic-method-tostring.php';
+		$this->analyse(
+			[__DIR__ . '/data/echo-deprecated-magic-method-tostring.php'],
+			[
+				[
+					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
+					6,
+				]
+			]
+		);
+	}
+
+}

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -36,8 +36,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					10,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					13,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					11,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -46,6 +46,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					15,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					16,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					17,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -68,8 +68,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					18,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					21,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					19,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -110,6 +110,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					31,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					32,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					33,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -48,8 +48,8 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					13,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					16,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					14,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
@@ -70,6 +70,14 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					21,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					22,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					23,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -24,11 +24,11 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 			[__DIR__ . '/data/echo-deprecated-magic-method-tostring.php'],
 			[
 				[
-					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
 					8,
 				],
 				[
-					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
 					9,
 				],
 			]

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -32,12 +32,20 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					9,
 				],
 				[
-					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
-					12,
+					'Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBar.',
+					10,
 				],
 				[
 					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
 					13,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					14,
+				],
+				[
+					"Call to deprecated method __toString() of class EchoDeprecatedToStringRule\MagicBarWithDesc:\nuse XY instead.",
+					15,
 				],
 			]
 		);

--- a/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
+++ b/tests/Rules/Deprecations/EchoDeprecatedToStringRuleTest.php
@@ -27,6 +27,10 @@ class EchoDeprecatedToStringRuleTest extends \PHPStan\Testing\RuleTestCase
 					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
 					8,
 				],
+				[
+					'Call to deprecated method __toString() of class CheckDeprecatedStaticMethodCall\MagicBar.',
+					9,
+				],
 			]
 		);
 	}

--- a/tests/Rules/Deprecations/data/echo-deprecated-binaryop-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-binaryop-magic-method-tostring.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EchoDeprecatedBinaryOpToStringRule;
+
+function ()
+{
+	$bar = new MagicBar();
+	echo "" == $bar;
+	echo "" != $bar;
+	echo "" === $bar;
+	echo "" !== $bar;
+	echo "" <=> $bar;
+
+	$barDesc = new MagicBarWithDesc();
+	echo "" == $barDesc;
+	echo "" != $barDesc;
+	echo "" === $barDesc;
+	echo "" !== $barDesc;
+	echo "" <=> $barDesc;
+
+	$noDeps = new NoDeprecation();
+	echo "" == $noDeps;
+	echo "" != $noDeps;
+	echo "" === $noDeps;
+	echo "" !== $noDeps;
+	echo "" <=> $noDeps;
+};
+
+class MagicBar
+{
+	/**
+	 * @deprecated
+	 */
+	public function __toString()
+	{
+		return 'a string';
+	}
+}
+
+class MagicBarWithDesc
+{
+	/**
+	 * @deprecated use XY instead.
+	 */
+	public function __toString()
+	{
+		return 'a string';
+	}
+}
+
+class NoDeprecation
+{
+	public function __toString()
+	{
+		return 'a string';
+	}
+}

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -13,6 +13,7 @@ function ()
 	echo "la". ($x=$bar) . "lu";
 	echo "la". ($x.=$bar) . "lu";
 	echo "" ?: $bar;
+	echo $_GET['doesNotExist'] ?? $bar;
 	echo "" == $bar;
 	echo "" != $bar;
 	echo "" === $bar;
@@ -28,6 +29,7 @@ function ()
 	echo "la". ($x=$barDesc) . "lu";
 	echo "la". ($x.=$barDesc) . "lu";
 	echo "" ?: $barDesc;
+	echo $_GET['doesNotExist'] ?? $barDesc;
 	echo "" == $barDesc;
 	echo "" != $barDesc;
 	echo "" === $barDesc;
@@ -43,6 +45,7 @@ function ()
 	echo "la". ($x=$noDeps) . "lu";
 	echo "la". ($x.=$noDeps) . "lu";
 	echo "" ?: $noDeps;
+	echo $_GET['doesNotExist'] ?? $noDeps;
 	echo "" == $noDeps;
 	echo "" != $noDeps;
 	echo "" === $noDeps;

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -11,6 +11,7 @@ function ()
 	echo "la". (string)($bar) . "lu";
 	echo "la". ($x=$bar) . "lu";
 	echo "la". ($x.=$bar) . "lu";
+	echo "" ?: $bar;
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
@@ -19,6 +20,7 @@ function ()
 	echo "la". (string)($barDesc) . "lu";
 	echo "la". ($x=$barDesc) . "lu";
 	echo "la". ($x.=$barDesc) . "lu";
+	echo "" ?: $barDesc;
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
@@ -27,6 +29,7 @@ function ()
 	echo "la". (string)($noDeps) . "lu";
 	echo "la". ($x=$noDeps) . "lu";
 	echo "la". ($x.=$noDeps) . "lu";
+	echo "" ?: $noDeps;
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CheckDeprecatedStaticMethodCall;
+
+$bar = new MagicBar();
+echo $bar;
+
+class MagicBar
+{
+	/**
+	 * @deprecated
+	 */
+	public function __toString()
+	{
+		return 'a string';
+	}
+}

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -6,6 +6,7 @@ function ()
 {
 	$bar = new MagicBar();
 	echo $bar;
+	echo $bar . "hallo";
 };
 
 class MagicBar

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -9,18 +9,21 @@ function ()
 	echo $bar . "hallo";
 	echo "la". ($bar."3") . "lu";
 	echo "la". (string)($bar) . "lu";
+	echo "la". ($x=$bar) . "lu";
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
 	echo $barDesc . "hallo";
 	echo "la". ($barDesc."3") . "lu";
 	echo "la". (string)($barDesc) . "lu";
+	echo "la". ($x=$barDesc) . "lu";
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
 	echo $noDeps . "hallo";
 	echo "la". ($noDeps."3") . "lu";
 	echo "la". (string)($noDeps) . "lu";
+	echo "la". ($x=$noDeps) . "lu";
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -16,6 +16,7 @@ function ()
 	echo "" != $bar;
 	echo "" === $bar;
 	echo "" !== $bar;
+	echo "" <=> $bar;
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
@@ -29,6 +30,7 @@ function ()
 	echo "" != $barDesc;
 	echo "" === $barDesc;
 	echo "" !== $barDesc;
+	echo "" <=> $barDesc;
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
@@ -42,6 +44,7 @@ function ()
 	echo "" != $noDeps;
 	echo "" === $noDeps;
 	echo "" !== $noDeps;
+	echo "" <=> $noDeps;
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -13,6 +13,7 @@ function ()
 	echo "la". ($x.=$bar) . "lu";
 	echo "" ?: $bar;
 	echo "" == $bar;
+	echo "" != $bar;
 	echo "" === $bar;
 
 	$barDesc = new MagicBarWithDesc();
@@ -24,6 +25,7 @@ function ()
 	echo "la". ($x.=$barDesc) . "lu";
 	echo "" ?: $barDesc;
 	echo "" == $barDesc;
+	echo "" != $barDesc;
 	echo "" === $barDesc;
 
 	$noDeps = new NoDeprecation();
@@ -35,6 +37,7 @@ function ()
 	echo "la". ($x.=$noDeps) . "lu";
 	echo "" ?: $noDeps;
 	echo "" == $noDeps;
+	echo "" != $noDeps;
 	echo "" === $noDeps;
 
 	echo "la". "le" . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -11,6 +11,10 @@ function ()
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
 	echo $barDesc . "hallo";
+
+	$noDeps = new NoDeprecation();
+	echo $noDeps;
+	echo $noDeps . "hallo";
 };
 
 class MagicBar
@@ -29,6 +33,14 @@ class MagicBarWithDesc
 	/**
 	 * @deprecated use XY instead.
 	 */
+	public function __toString()
+	{
+		return 'a string';
+	}
+}
+
+class NoDeprecation
+{
 	public function __toString()
 	{
 		return 'a string';

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -12,6 +12,7 @@ function ()
 	echo "la". ($x=$bar) . "lu";
 	echo "la". ($x.=$bar) . "lu";
 	echo "" ?: $bar;
+	echo "" == $bar;
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
@@ -21,6 +22,7 @@ function ()
 	echo "la". ($x=$barDesc) . "lu";
 	echo "la". ($x.=$barDesc) . "lu";
 	echo "" ?: $barDesc;
+	echo "" == $barDesc;
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
@@ -30,6 +32,7 @@ function ()
 	echo "la". ($x=$noDeps) . "lu";
 	echo "la". ($x.=$noDeps) . "lu";
 	echo "" ?: $noDeps;
+	echo "" == $noDeps;
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CheckDeprecatedStaticMethodCall;
+namespace EchoDeprecatedToStringRule;
 
 function ()
 {

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -10,6 +10,7 @@ function ()
 	echo "la". ($bar."3") . "lu";
 	echo "la". (string)($bar) . "lu";
 	echo "la". ($x=$bar) . "lu";
+	echo "la". ($x.=$bar) . "lu";
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
@@ -17,6 +18,7 @@ function ()
 	echo "la". ($barDesc."3") . "lu";
 	echo "la". (string)($barDesc) . "lu";
 	echo "la". ($x=$barDesc) . "lu";
+	echo "la". ($x.=$barDesc) . "lu";
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
@@ -24,6 +26,7 @@ function ()
 	echo "la". ($noDeps."3") . "lu";
 	echo "la". (string)($noDeps) . "lu";
 	echo "la". ($x=$noDeps) . "lu";
+	echo "la". ($x.=$noDeps) . "lu";
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -7,14 +7,22 @@ function ()
 	$bar = new MagicBar();
 	echo $bar;
 	echo $bar . "hallo";
+	echo "la". ($bar."3") . "lu";
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
 	echo $barDesc . "hallo";
+	echo "la". ($barDesc."3") . "lu";
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
 	echo $noDeps . "hallo";
+	echo "la". ($noDeps."3") . "lu";
+
+	echo "la". "le" . "lu";
+	echo "la". 5 . "lu";
+	echo "la". (5+3) . "lu";
+	echo "la". (5*3) . "lu";
 };
 
 class MagicBar

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -7,12 +7,27 @@ function ()
 	$bar = new MagicBar();
 	echo $bar;
 	echo $bar . "hallo";
+
+	$barDesc = new MagicBarWithDesc();
+	echo $barDesc;
+	echo $barDesc . "hallo";
 };
 
 class MagicBar
 {
 	/**
 	 * @deprecated
+	 */
+	public function __toString()
+	{
+		return 'a string';
+	}
+}
+
+class MagicBarWithDesc
+{
+	/**
+	 * @deprecated use XY instead.
 	 */
 	public function __toString()
 	{

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -2,8 +2,11 @@
 
 namespace CheckDeprecatedStaticMethodCall;
 
-$bar = new MagicBar();
-echo $bar;
+function ()
+{
+	$bar = new MagicBar();
+	echo $bar;
+};
 
 class MagicBar
 {

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -15,6 +15,7 @@ function ()
 	echo "" == $bar;
 	echo "" != $bar;
 	echo "" === $bar;
+	echo "" !== $bar;
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
@@ -27,6 +28,7 @@ function ()
 	echo "" == $barDesc;
 	echo "" != $barDesc;
 	echo "" === $barDesc;
+	echo "" !== $barDesc;
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
@@ -39,6 +41,7 @@ function ()
 	echo "" == $noDeps;
 	echo "" != $noDeps;
 	echo "" === $noDeps;
+	echo "" !== $noDeps;
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -7,6 +7,7 @@ function ()
 	$bar = new MagicBar();
 	echo $bar;
 	echo $bar . "hallo";
+	echo "{$bar}";
 	echo "la". ($bar."3") . "lu";
 	echo "la". (string)($bar) . "lu";
 	echo "la". ($x=$bar) . "lu";
@@ -21,6 +22,7 @@ function ()
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
 	echo $barDesc . "hallo";
+	echo "{$barDesc}";
 	echo "la". ($barDesc."3") . "lu";
 	echo "la". (string)($barDesc) . "lu";
 	echo "la". ($x=$barDesc) . "lu";
@@ -35,6 +37,7 @@ function ()
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
 	echo $noDeps . "hallo";
+	echo "{$noDeps}";
 	echo "la". ($noDeps."3") . "lu";
 	echo "la". (string)($noDeps) . "lu";
 	echo "la". ($x=$noDeps) . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -13,6 +13,7 @@ function ()
 	echo "la". ($x.=$bar) . "lu";
 	echo "" ?: $bar;
 	echo "" == $bar;
+	echo "" === $bar;
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
@@ -23,6 +24,7 @@ function ()
 	echo "la". ($x.=$barDesc) . "lu";
 	echo "" ?: $barDesc;
 	echo "" == $barDesc;
+	echo "" === $barDesc;
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
@@ -33,6 +35,7 @@ function ()
 	echo "la". ($x.=$noDeps) . "lu";
 	echo "" ?: $noDeps;
 	echo "" == $noDeps;
+	echo "" === $noDeps;
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";

--- a/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
+++ b/tests/Rules/Deprecations/data/echo-deprecated-magic-method-tostring.php
@@ -8,16 +8,19 @@ function ()
 	echo $bar;
 	echo $bar . "hallo";
 	echo "la". ($bar."3") . "lu";
+	echo "la". (string)($bar) . "lu";
 
 	$barDesc = new MagicBarWithDesc();
 	echo $barDesc;
 	echo $barDesc . "hallo";
 	echo "la". ($barDesc."3") . "lu";
+	echo "la". (string)($barDesc) . "lu";
 
 	$noDeps = new NoDeprecation();
 	echo $noDeps;
 	echo $noDeps . "hallo";
 	echo "la". ($noDeps."3") . "lu";
+	echo "la". (string)($noDeps) . "lu";
 
 	echo "la". "le" . "lu";
 	echo "la". 5 . "lu";


### PR DESCRIPTION
with this change phpstan is able to detect cases, where object values are used in `echo` statements and implicitly call a magic and deprecated `__toString` method.

In case this new rule gets accepted, I would be willing to implement the same for the `print` statement.

refs https://github.com/phpstan/phpstan/issues/4899