### PR TITLE
Fix deprecationRulesInstalled not being set to true automatically

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,5 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
-	deprecationRulesInstalled: true
 	excludePaths:
 		- tests/*/data/*

--- a/rules.neon
+++ b/rules.neon
@@ -2,6 +2,9 @@ services:
     -
         class: PHPStan\Rules\Deprecations\DeprecatedClassHelper
 
+parameters:
+    deprecationRulesInstalled: true
+
 rules:
 	- PHPStan\Rules\Deprecations\AccessDeprecatedPropertyRule
 	- PHPStan\Rules\Deprecations\AccessDeprecatedStaticPropertyRule


### PR DESCRIPTION
I tried to implement this for static PHPUnit `dataProvider`'s from `phpstan/phpstan-phpunit` and couldn't get it to work without myself overriding the parameter value in our own `phpstan.neon` configuration.

I've dropped it from `phpstan.neon` as well as I _believe_ that's redundant now.