### PR TITLE
Report deprecated properties accessed by self

### DIFF
--- a/src/Rules/Deprecations/AccessDeprecatedStaticPropertyRule.php
+++ b/src/Rules/Deprecations/AccessDeprecatedStaticPropertyRule.php
@@ -53,7 +53,7 @@ class AccessDeprecatedStaticPropertyRule implements Rule
 		$referencedClasses = [];
 
 		if ($node->class instanceof Name) {
-			$referencedClasses[] = (string) $node->class;
+			$referencedClasses[] = $scope->resolveName($node->class);
 		} else {
 			$classTypeResult = $this->ruleLevelHelper->findTypeToCheck(
 				$scope,
@@ -87,14 +87,14 @@ class AccessDeprecatedStaticPropertyRule implements Rule
 					return [sprintf(
 						'Access to deprecated static property $%s of class %s.',
 						$propertyName,
-						$referencedClass
+						$property->getDeclaringClass()->getName()
 					)];
 				}
 
 				return [sprintf(
 					"Access to deprecated static property $%s of class %s:\n%s",
 					$propertyName,
-					$referencedClass,
+					$property->getDeclaringClass()->getName(),
 					$description
 				)];
 			}

--- a/tests/Rules/Deprecations/AccessDeprecatedStaticPropertyRuleTest.php
+++ b/tests/Rules/Deprecations/AccessDeprecatedStaticPropertyRuleTest.php
@@ -59,6 +59,22 @@ class AccessDeprecatedStaticPropertyRuleTest extends RuleTestCase
 					"Access to deprecated static property \$deprecatedWithDescription of class AccessDeprecatedStaticProperty\Foo:\nThis is probably a singleton.",
 					33,
 				],
+				[
+					'Access to deprecated static property $deprecatedFoo of class AccessDeprecatedStaticProperty\Foo.',
+					117,
+				],
+				[
+					'Access to deprecated static property $deprecatedOtherFoo of class AccessDeprecatedStaticProperty\Child.',
+					118,
+				],
+				[
+					'Access to deprecated static property $deprecatedFoo of class AccessDeprecatedStaticProperty\Foo.',
+					119,
+				],
+				[
+					'Access to deprecated static property $deprecatedOtherFoo of class AccessDeprecatedStaticProperty\Child.',
+					120,
+				],
 			]
 		);
 	}

--- a/tests/Rules/Deprecations/CallToDeprecatedStaticMethodRuleTest.php
+++ b/tests/Rules/Deprecations/CallToDeprecatedStaticMethodRuleTest.php
@@ -67,6 +67,22 @@ class CallToDeprecatedStaticMethodRuleTest extends RuleTestCase
 					'Call to deprecated method deprecatedFoo() of class CheckDeprecatedStaticMethodCall\Foo.',
 					33,
 				],
+				[
+					'Call to deprecated method deprecatedFoo() of class CheckDeprecatedStaticMethodCall\Foo.',
+					74,
+				],
+				[
+					'Call to deprecated method deprecatedOtherFoo() of class CheckDeprecatedStaticMethodCall\Child.',
+					75,
+				],
+				[
+					'Call to deprecated method deprecatedFoo() of class CheckDeprecatedStaticMethodCall\Foo.',
+					76,
+				],
+				[
+					'Call to deprecated method deprecatedOtherFoo() of class CheckDeprecatedStaticMethodCall\Child.',
+					77,
+				],
 			]
 		);
 	}

--- a/tests/Rules/Deprecations/data/access-deprecated-static-property.php
+++ b/tests/Rules/Deprecations/data/access-deprecated-static-property.php
@@ -104,3 +104,19 @@ class DeprecatedScope
 	}
 
 }
+
+class Child extends Foo
+{
+	/**
+	 * @deprecated
+	 */
+	public static $deprecatedOtherFoo;
+
+	public static function foo()
+	{
+		self::$deprecatedFoo;
+		self::$deprecatedOtherFoo;
+		static::$deprecatedFoo;
+		static::$deprecatedOtherFoo;
+	}
+}

--- a/tests/Rules/Deprecations/data/call-to-deprecated-static-method.php
+++ b/tests/Rules/Deprecations/data/call-to-deprecated-static-method.php
@@ -58,3 +58,22 @@ class DeprecatedScope
 	}
 
 }
+
+class Child extends Foo
+{
+	/**
+	 * @deprecated
+	 */
+	public static function deprecatedOtherFoo()
+	{
+
+	}
+
+	public static function foo()
+	{
+		self::deprecatedFoo();
+		self::deprecatedOtherFoo();
+		static::deprecatedFoo();
+		static::deprecatedOtherFoo();
+	}
+}


### PR DESCRIPTION
Fixed #88 

As it turned out, properties accessed by `self::$foo` were in general not reported.