### PR TITLE
Fix a typo

### DIFF
--- a/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class-definition.php
+++ b/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class-definition.php
@@ -31,7 +31,7 @@ class Property
 
 }
 
-interface IThinkYourStucked
+interface IThinkYourStuck
 {
 
     /**

--- a/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class-definition.php
+++ b/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class-definition.php
@@ -31,7 +31,7 @@ class Property
 
 }
 
-interface IThinkYourStuck
+interface IThinkYoureStuck
 {
 
     /**

--- a/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class.php
+++ b/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class.php
@@ -32,7 +32,7 @@ class Foo
 
 }
 
-class FooImplOverride implements IThinkYourStucked
+class FooImplOverride implements IThinkYourStuck
 {
 
     /**
@@ -44,7 +44,7 @@ class FooImplOverride implements IThinkYourStucked
 
 }
 
-class FooImplNoOverride implements IThinkYourStucked
+class FooImplNoOverride implements IThinkYourStuck
 {
 
     public function oops($property): void

--- a/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class.php
+++ b/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class.php
@@ -32,7 +32,7 @@ class Foo
 
 }
 
-class FooImplOverride implements IThinkYourStuck
+class FooImplOverride implements IThinkYoureStuck
 {
 
     /**
@@ -44,7 +44,7 @@ class FooImplOverride implements IThinkYourStuck
 
 }
 
-class FooImplNoOverride implements IThinkYourStuck
+class FooImplNoOverride implements IThinkYoureStuck
 {
 
     public function oops($property): void


### PR DESCRIPTION
"Your stucked" is really ["you're stuck"](https://www.merriam-webster.com/thesaurus/stuck), the past participle of _stick_.

[_source_](https://github.com/szepeviktor/byte-level-care/blob/master/.github/workflows/spelling.yml)
