### PR TITLE
Report FILTER_SANITIZE_STRING as deprecated in PHP8.1+

### DIFF
--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -73,10 +73,19 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 
 		if (PHP_VERSION_ID >= 80100) {
 			$expectedErrors[] = [
-				'Use of constant FILTER_SANITIZE_STRING is deprecated since PHP 8.1.',
-				5,
+				'Use of constant FILTER_SANITIZE_STRING is deprecated.',
+				8,
 			];
 		}
+		
+		$expectedErrors[] = [
+			'Use of constant MY_CONST is deprecated.',
+			17,
+		];
+		$expectedErrors[] = [
+			'Use of constant MY_CONST2 is deprecated.',
+			25,
+		];
 
 		require_once __DIR__ . '/data/fetching-deprecated-filter-const.php';
 		$this->analyse(

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -77,7 +77,7 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 				8,
 			];
 		}
-		
+
 		$expectedErrors[] = [
 			'Use of constant MY_CONST is deprecated.',
 			17,

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -63,4 +63,26 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testDeprecatedFilterConsts()
+	{
+		if (!defined('FILTER_SANITIZE_STRING')) {
+			$this->markTestSkipped('Required constants are not available');
+		}
+
+		$expectedErrors = [];
+
+		if (PHP_VERSION_ID >= 80100) {
+			$expectedErrors[] = [
+				'Use of constant FILTER_SANITIZE_STRING is deprecated since PHP 8.1.',
+				5,
+			];
+		}
+
+		require_once __DIR__ . '/data/fetching-deprecated-filter-const.php';
+		$this->analyse(
+			[__DIR__ . '/data/fetching-deprecated-filter-const.php'],
+			$expectedErrors
+		);
+	}
+
 }

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Deprecations;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use function defined;
@@ -17,7 +18,8 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 	{
 		return new FetchingDeprecatedConstRule(
 			$this->createReflectionProvider(),
-			new DeprecatedScopeHelper([new DefaultDeprecatedScopeResolver()])
+			new DeprecatedScopeHelper([new DefaultDeprecatedScopeResolver()]),
+			self::getContainer()->getByType(PhpVersion::class)
 		);
 	}
 

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -63,7 +63,7 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 		);
 	}
 
-	public function testDeprecatedFilterConsts()
+	public function testDeprecatedFilterConsts(): void
 	{
 		if (!defined('FILTER_SANITIZE_STRING')) {
 			$this->markTestSkipped('Required constants are not available');

--- a/tests/Rules/Deprecations/data/fetching-deprecated-filter-const.php
+++ b/tests/Rules/Deprecations/data/fetching-deprecated-filter-const.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DeprecatedFilterConst;
+
+function doFoo(mixed $filter): void {
+	$x = filter_input(INPUT_GET,
+		'search',
+		FILTER_SANITIZE_STRING
+	);
+}

--- a/tests/Rules/Deprecations/data/fetching-deprecated-filter-const.php
+++ b/tests/Rules/Deprecations/data/fetching-deprecated-filter-const.php
@@ -8,3 +8,18 @@ function doFoo(mixed $filter): void {
 		FILTER_SANITIZE_STRING
 	);
 }
+
+/**
+ * @deprecated
+ */
+const MY_CONST = '1';
+
+echo MY_CONST;
+
+
+/**
+ * @deprecated don't use it!
+ */
+const MY_CONST2 = '1';
+
+echo MY_CONST2;


### PR DESCRIPTION
regression test for https://github.com/phpstan/phpstan/issues/10662

[requires a fix in phpstan-src](https://github.com/phpstan/phpstan-src/pull/2953)

todo: raise min phpstan version in composer.json