### PR TITLE
Removed always true PHP_VERSION_ID condition

### DIFF
--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -5,7 +5,6 @@ namespace PHPStan\Rules\Deprecations;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use function defined;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<FetchingDeprecatedConstRule>
@@ -28,33 +27,30 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 		}
 
 		$expectedErrors = [];
-
-		if (PHP_VERSION_ID >= 70300) {
-			$expectedErrors[] = [
-				'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated.',
-				5,
-			];
-			$expectedErrors[] = [
-				'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated.',
-				6,
-			];
-			$expectedErrors[] = [
-				'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated.',
-				7,
-			];
-			$expectedErrors[] = [
-				'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated.',
-				8,
-			];
-			$expectedErrors[] = [
-				'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated.',
-				37,
-			];
-			$expectedErrors[] = [
-				'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated.',
-				38,
-			];
-		}
+		$expectedErrors[] = [
+			'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated.',
+			5,
+		];
+		$expectedErrors[] = [
+			'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated.',
+			6,
+		];
+		$expectedErrors[] = [
+			'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated.',
+			7,
+		];
+		$expectedErrors[] = [
+			'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated.',
+			8,
+		];
+		$expectedErrors[] = [
+			'Use of constant FILTER_FLAG_SCHEME_REQUIRED is deprecated.',
+			37,
+		];
+		$expectedErrors[] = [
+			'Use of constant FILTER_FLAG_HOST_REQUIRED is deprecated.',
+			38,
+		];
 
 		require_once __DIR__ . '/data/fetching-deprecated-const-definition.php';
 		$this->analyse(


### PR DESCRIPTION
because of raised min-php version

identified via https://github.com/phpstan/phpstan-src/pull/3584