### PR TITLE
Do not report at attribute line

### DIFF
--- a/src/Rules/Deprecations/InheritanceOfDeprecatedClassRule.php
+++ b/src/Rules/Deprecations/InheritanceOfDeprecatedClassRule.php
@@ -55,6 +55,7 @@ class InheritanceOfDeprecatedClassRule implements Rule
 		}
 
 		$parentClassName = (string) $node->extends;
+		$line = $node->name !== null ? $node->name->getStartLine() : $node->getStartLine();
 
 		try {
 			$parentClass = $this->reflectionProvider->getClass($parentClassName);
@@ -66,27 +67,27 @@ class InheritanceOfDeprecatedClassRule implements Rule
 							'Class %s extends deprecated class %s.',
 							$className,
 							$parentClassName,
-						))->identifier('class.extendsDeprecatedClass')->build();
+						))->identifier('class.extendsDeprecatedClass')->line($line)->build();
 					} else {
 						$errors[] = RuleErrorBuilder::message(sprintf(
 							"Class %s extends deprecated class %s:\n%s",
 							$className,
 							$parentClassName,
 							$description,
-						))->identifier('class.extendsDeprecatedClass')->build();
+						))->identifier('class.extendsDeprecatedClass')->line($line)->build();
 					}
 				} else {
 					if ($description === null) {
 						$errors[] = RuleErrorBuilder::message(sprintf(
 							'Anonymous class extends deprecated class %s.',
 							$parentClassName,
-						))->identifier('class.extendsDeprecatedClass')->build();
+						))->identifier('class.extendsDeprecatedClass')->line($line)->build();
 					} else {
 						$errors[] = RuleErrorBuilder::message(sprintf(
 							"Anonymous class extends deprecated class %s:\n%s",
 							$parentClassName,
 							$description,
-						))->identifier('class.extendsDeprecatedClass')->build();
+						))->identifier('class.extendsDeprecatedClass')->line($line)->build();
 					}
 				}
 			}

--- a/src/Rules/Deprecations/InheritanceOfDeprecatedInterfaceRule.php
+++ b/src/Rules/Deprecations/InheritanceOfDeprecatedInterfaceRule.php
@@ -45,6 +45,7 @@ class InheritanceOfDeprecatedInterfaceRule implements Rule
 			return [];
 		}
 
+		$line = $node->name !== null ? $node->name->getStartLine() : $node->getStartLine();
 		$errors = [];
 
 		foreach ($node->extends as $parentInterfaceName) {
@@ -63,14 +64,14 @@ class InheritanceOfDeprecatedInterfaceRule implements Rule
 						'Interface %s extends deprecated interface %s.',
 						$interfaceName,
 						$parentInterfaceName,
-					))->identifier('interface.extendsDeprecatedInterface')->build();
+					))->identifier('interface.extendsDeprecatedInterface')->line($line)->build();
 				} else {
 					$errors[] = RuleErrorBuilder::message(sprintf(
 						"Interface %s extends deprecated interface %s:\n%s",
 						$interfaceName,
 						$parentInterfaceName,
 						$description,
-					))->identifier('interface.extendsDeprecatedInterface')->build();
+					))->identifier('interface.extendsDeprecatedInterface')->line($line)->build();
 				}
 			} catch (ClassNotFoundException $e) {
 				// Other rules will notify if the interface is not found

--- a/src/Rules/Deprecations/TypeHintDeprecatedInClassMethodSignatureRule.php
+++ b/src/Rules/Deprecations/TypeHintDeprecatedInClassMethodSignatureRule.php
@@ -38,6 +38,7 @@ class TypeHintDeprecatedInClassMethodSignatureRule implements Rule
 		}
 
 		$method = $node->getMethodReflection();
+		$line = $node->getOriginalNode()->name->getStartLine();
 
 		$errors = [];
 		foreach ($method->getParameters() as $parameter) {
@@ -51,7 +52,7 @@ class TypeHintDeprecatedInClassMethodSignatureRule implements Rule
 						strtolower($deprecatedClass->getClassTypeDescription()),
 						$deprecatedClass->getName(),
 						$this->deprecatedClassHelper->getClassDeprecationDescription($deprecatedClass),
-					))->identifier(sprintf('parameter.deprecated%s', $deprecatedClass->getClassTypeDescription()))->build();
+					))->identifier(sprintf('parameter.deprecated%s', $deprecatedClass->getClassTypeDescription()))->line($line)->build();
 				} else {
 					$errors[] = RuleErrorBuilder::message(sprintf(
 						'Parameter $%s of method %s::%s() has typehint with deprecated %s %s%s',
@@ -61,7 +62,7 @@ class TypeHintDeprecatedInClassMethodSignatureRule implements Rule
 						strtolower($deprecatedClass->getClassTypeDescription()),
 						$deprecatedClass->getName(),
 						$this->deprecatedClassHelper->getClassDeprecationDescription($deprecatedClass),
-					))->identifier(sprintf('parameter.deprecated%s', $deprecatedClass->getClassTypeDescription()))->build();
+					))->identifier(sprintf('parameter.deprecated%s', $deprecatedClass->getClassTypeDescription()))->line($line)->build();
 				}
 			}
 		}
@@ -75,7 +76,7 @@ class TypeHintDeprecatedInClassMethodSignatureRule implements Rule
 					strtolower($deprecatedClass->getClassTypeDescription()),
 					$deprecatedClass->getName(),
 					$this->deprecatedClassHelper->getClassDeprecationDescription($deprecatedClass),
-				))->identifier(sprintf('return.deprecated%s', $deprecatedClass->getClassTypeDescription()))->build();
+				))->identifier(sprintf('return.deprecated%s', $deprecatedClass->getClassTypeDescription()))->line($line)->build();
 			} else {
 				$errors[] = RuleErrorBuilder::message(sprintf(
 					'Return type of method %s::%s() has typehint with deprecated %s %s%s',
@@ -84,7 +85,7 @@ class TypeHintDeprecatedInClassMethodSignatureRule implements Rule
 					strtolower($deprecatedClass->getClassTypeDescription()),
 					$deprecatedClass->getName(),
 					$this->deprecatedClassHelper->getClassDeprecationDescription($deprecatedClass),
-				))->identifier(sprintf('return.deprecated%s', $deprecatedClass->getClassTypeDescription()))->build();
+				))->identifier(sprintf('return.deprecated%s', $deprecatedClass->getClassTypeDescription()))->line($line)->build();
 			}
 		}
 

--- a/tests/Rules/Deprecations/InheritanceOfDeprecatedClassRuleTest.php
+++ b/tests/Rules/Deprecations/InheritanceOfDeprecatedClassRuleTest.php
@@ -33,6 +33,10 @@ class InheritanceOfDeprecatedClassRuleTest extends RuleTestCase
 					"Class InheritanceOfDeprecatedClass\Bar3 extends deprecated class InheritanceOfDeprecatedClass\DeprecatedWithDescription:\nInheritance is deprecated.",
 					15,
 				],
+				[
+					"Class InheritanceOfDeprecatedClass\Bar4 extends deprecated class InheritanceOfDeprecatedClass\DeprecatedWithDescription:\nInheritance is deprecated.",
+					21,
+				],
 			],
 		);
 	}

--- a/tests/Rules/Deprecations/InheritanceOfDeprecatedInterfaceRuleTest.php
+++ b/tests/Rules/Deprecations/InheritanceOfDeprecatedInterfaceRuleTest.php
@@ -38,6 +38,10 @@ class InheritanceOfDeprecatedInterfaceRuleTest extends RuleTestCase
 					"Interface InheritanceOfDeprecatedInterface\Foo4 extends deprecated interface InheritanceOfDeprecatedInterface\DeprecatedWithDescription:\nImplement something else.",
 					20,
 				],
+				[
+					'Interface InheritanceOfDeprecatedInterface\Foo4 extends deprecated interface InheritanceOfDeprecatedInterface\DeprecatedFooable.',
+					50,
+				],
 			],
 		);
 	}

--- a/tests/Rules/Deprecations/TypeHintDeprecatedInClassMethodSignatureRuleTest.php
+++ b/tests/Rules/Deprecations/TypeHintDeprecatedInClassMethodSignatureRuleTest.php
@@ -33,6 +33,7 @@ class TypeHintDeprecatedInClassMethodSignatureRuleTest extends RuleTestCase
 				['Parameter $property of method TypeHintDeprecatedInClassMethodSignature\FooImplNoOverride::oops() has typehint with deprecated class TypeHintDeprecatedInClassMethodSignature\DeprecatedProperty.', 50],
 				['Parameter $property of method __construct() in anonymous class has typehint with deprecated class TypeHintDeprecatedInClassMethodSignature\DeprecatedProperty.', 71],
 				['Return type of method getProperty() in anonymous class has typehint with deprecated class TypeHintDeprecatedInClassMethodSignature\DeprecatedProperty.', 76],
+				['Return type of method methodWithAttribute() in anonymous class has typehint with deprecated class TypeHintDeprecatedInClassMethodSignature\DeprecatedProperty.', 82],
 			],
 		);
 	}

--- a/tests/Rules/Deprecations/data/inheritance-of-deprecated-class-in-classes.php
+++ b/tests/Rules/Deprecations/data/inheritance-of-deprecated-class-in-classes.php
@@ -16,3 +16,9 @@ class Bar3 extends DeprecatedWithDescription
 {
 
 }
+
+#[SomeAttribute]
+class Bar4 extends DeprecatedWithDescription
+{
+
+}

--- a/tests/Rules/Deprecations/data/inheritance-of-deprecated-interface.php
+++ b/tests/Rules/Deprecations/data/inheritance-of-deprecated-interface.php
@@ -45,3 +45,9 @@ interface DeprecatedFoo3 extends Fooable, DeprecatedFooable, DeprecatedFooable2
 {
 
 }
+
+#[SomeAttribute]
+interface Foo4 extends Fooable, DeprecatedFooable
+{
+
+}

--- a/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class.php
+++ b/tests/Rules/Deprecations/data/typehint-class-method-deprecated-class.php
@@ -77,4 +77,11 @@ new class {
     {
         return $this->property;
     }
+
+	#[SomeAttribute]
+    public function methodWithAttribute(): ?DeprecatedProperty
+    {
+        return $this->property;
+    }
+
 };


### PR DESCRIPTION
I believe it is misleading to report at the first attribute line. Most visible when you inline ignore it. One real world example from our codebase:

```php
#[Get('/api/v1/foo')] // @phpstan-ignore return.deprecatedClass
#[OwnedBy(Team::D2C)]
public function someAction(): DeprecatedClass
{
```

This is minor BC, but I think moving few inline ignores is not that big deal. If you feel otherwise, we can use bleedingEdge.