### PR TITLE
Fix mutation testing on dev branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,8 +207,14 @@ jobs:
           > infection.json5
           cat infection.json5 | jq
 
-      - name: "Cache Result cache"
-        uses: actions/cache@v4
+      - name: "Determine default branch"
+        id: default-branch
+        working-directory: phpstan-dist
+        run: |
+          echo "name=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')" >> $GITHUB_OUTPUT
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
         with:
           path: ./tmp
           key: "result-cache-v1-${{ matrix.php-version }}-${{ github.run_id }}"
@@ -217,9 +223,9 @@ jobs:
 
       - name: "Run infection"
         run: |
-          git fetch --depth=1 origin $GITHUB_BASE_REF
+          git fetch --depth=1 origin ${{ steps.previous-commit.outputs.name }}
           infection \
-            --git-diff-base=origin/$GITHUB_BASE_REF \
+            --git-diff-base=origin/${{ steps.previous-commit.outputs.name }} \
             --git-diff-lines \
             --ignore-msi-with-no-mutations \
             --min-msi=100 \
@@ -227,3 +233,10 @@ jobs:
             --log-verbosity=all \
             --debug \
             --logger-text=php://stdout
+
+      - name: "Save result cache"
+        uses: actions/cache/save@v4
+        if: ${{ !cancelled() }}
+        with:
+          path: ./tmp
+          key: "result-cache-v1-${{ matrix.php-version }}-${{ github.run_id }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,9 +223,9 @@ jobs:
 
       - name: "Run infection"
         run: |
-          git fetch --depth=1 origin ${{ steps.previous-commit.outputs.name }}
+          git fetch --depth=1 origin ${{ steps.default-branch.outputs.name }}
           infection \
-            --git-diff-base=origin/${{ steps.previous-commit.outputs.name }} \
+            --git-diff-base=origin/${{ steps.default-branch.outputs.name }} \
             --git-diff-lines \
             --ignore-msi-with-no-mutations \
             --min-msi=100 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,6 @@ jobs:
 
       - name: "Determine default branch"
         id: default-branch
-        working-directory: phpstan-dist
         run: |
           echo "name=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')" >> $GITHUB_OUTPUT
 

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ cs-fix:
 
 .PHONY: phpstan
 phpstan:
-	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon src tests
+	php vendor/bin/phpstan analyse -c phpstan.neon src tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
+	level: 8
 	resultCachePath: tmp/resultCache.php
 
 	excludePaths:


### PR DESCRIPTION
shot in the dark, should fix

```
In Process.php line 112:
                                                                               
  The command "'git' 'diff' 'origin/' '--diff-filter' 'AM' '--name-only' '--'  
   'src'" failed.                                                              
                                                                               
  Exit Code: 128(Invalid exit argument)                                        
                                                                               
  Working directory: /home/runner/work/phpstan-deprecation-rules/phpstan-depr  
  ecation-rules                                                                
                                                                               
  Output:                                                                      
  ================                                                             
                                                                               
                                                                               
  Error Output:                                                                
  ================                                                             
  fatal: bad revision 'origin/'  
  ```