### PR TITLE
move analyse-paths into phpstan.neon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ cs-fix:
 
 .PHONY: phpstan
 phpstan:
-	php vendor/bin/phpstan analyse -c phpstan.neon src tests
+	php vendor/bin/phpstan analyse -c phpstan.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,5 +8,9 @@ parameters:
 	level: 8
 	resultCachePath: tmp/resultCache.php
 
+	paths:
+		- src
+		- tests
+
 	excludePaths:
 		- tests/*/data/*


### PR DESCRIPTION
should fix

```
In InitialStaticAnalysisRunFailed.php line 29:
                                                                               
  Project static analysis must be in a passing state before running Infection  
  .                                                                            
  PHPStan reported an exit code of 1.                                          
  Refer to the PHPStan's output below:                                         
  STDERR:                                                                      
  At least one path must be specified to analyse.           
  ```

in https://github.com/phpstan/build-infection/pull/15