### PR TITLE
Constants deprecation depends on Scope->getPhpVersion()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.1.15"
+		"phpstan/phpstan": "^2.1.34"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.1.34"
+		"phpstan/phpstan": "^2.1.39"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.2",

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -62,12 +62,7 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 
 	public function testEstrictWithVersionGuard(): void
 	{
-		$errors = [
-			[
-				'Use of constant E_STRICT is deprecated.',
-				7,
-			],
-		];
+		$errors = [];
 		if (PHP_VERSION_ID >= 80400) {
 			$errors = [
 				[

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Deprecations;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use function defined;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<FetchingDeprecatedConstRule>
@@ -61,10 +62,14 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 
 	public function testEstrictWithVersionGuard(): void
 	{
-		require_once __DIR__ . '/data/bug-162.php';
-		$this->analyse(
-			[__DIR__ . '/data/bug-162.php'],
+		$errors = [
 			[
+				'Use of constant E_STRICT is deprecated.',
+				7,
+			],
+		];
+		if (PHP_VERSION_ID >= 80400) {
+			$errors = [
 				[
 					'Use of constant E_STRICT is deprecated.',
 					7,
@@ -73,7 +78,13 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 					'Use of constant E_STRICT is deprecated.',
 					18,
 				],
-			],
+			];
+		}
+
+		require_once __DIR__ . '/data/bug-162.php';
+		$this->analyse(
+			[__DIR__ . '/data/bug-162.php'],
+			$errors,
 		);
 	}
 

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -67,13 +67,14 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 			[
 				[
 					'Use of constant E_STRICT is deprecated.',
-					7
+					7,
 				],
 				[
 					'Use of constant E_STRICT is deprecated.',
-					18
+					18,
 				],
 			],
 		);
 	}
+
 }

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -59,4 +59,21 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testEstrictWithVersionGuard(): void
+	{
+		require_once __DIR__ . '/data/bug-162.php';
+		$this->analyse(
+			[__DIR__ . '/data/bug-162.php'],
+			[
+				[
+					'Use of constant E_STRICT is deprecated.',
+					7
+				],
+				[
+					'Use of constant E_STRICT is deprecated.',
+					18
+				],
+			],
+		);
+	}
 }

--- a/tests/Rules/Deprecations/data/bug-162.php
+++ b/tests/Rules/Deprecations/data/bug-162.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug162;
+
+function foo(int $errno):void {
+	if (PHP_VERSION_ID >= 80400) {
+		if (E_STRICT === $errno) {
+
+		}
+	}
+
+	if (PHP_VERSION_ID < 80400) {
+		if (E_STRICT === $errno) {
+
+		}
+	}
+
+	if (E_STRICT === $errno ) {
+	}
+}


### PR DESCRIPTION
requires https://github.com/phpstan/phpstan-src/pull/4630

refs https://github.com/phpstan/phpstan-deprecation-rules/issues/162