### PR TITLE
Usage of deprecated E_STRICT is reported even though it's guarded

### DIFF
--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -83,4 +83,15 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testEstrictWithVersionCompareGuard(): void
+	{
+		$errors = [];
+
+		require_once __DIR__ . '/data/bug-162b.php';
+		$this->analyse(
+			[__DIR__ . '/data/bug-162b.php'],
+			$errors,
+		);
+	}
+
 }

--- a/tests/Rules/Deprecations/data/bug-162b.php
+++ b/tests/Rules/Deprecations/data/bug-162b.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bug162b;
+
+function foo(int $errno):void {
+	if (
+		version_compare( PHP_VERSION, '8.4', '<' )
+		&& E_STRICT === $errno
+	) {
+		// ...
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan-deprecation-rules/issues/162