### PR TITLE
Report deprecation when calling methods of a deprecated trait

### DIFF
--- a/src/Rules/Deprecations/RestrictedDeprecatedMethodUsageExtension.php
+++ b/src/Rules/Deprecations/RestrictedDeprecatedMethodUsageExtension.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Deprecations;
 
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Rules\RestrictedUsage\RestrictedMethodUsageExtension;
 use PHPStan\Rules\RestrictedUsage\RestrictedUsage;
@@ -63,6 +64,34 @@ class RestrictedDeprecatedMethodUsageExtension implements RestrictedMethodUsageE
 			);
 		}
 
+		$deprecatedDeclaringTrait = $this->findDeprecatedDeclaringTrait(
+			$methodReflection->getDeclaringClass(),
+			$methodReflection->getName(),
+		);
+		if ($deprecatedDeclaringTrait !== null) {
+			$traitDescription = $deprecatedDeclaringTrait->getDeprecatedDescription();
+			if ($traitDescription === null) {
+				return RestrictedUsage::create(
+					sprintf(
+						'Call to method %s() of deprecated trait %s.',
+						$methodReflection->getName(),
+						$deprecatedDeclaringTrait->getName(),
+					),
+					sprintf('%s.deprecatedTrait', $methodReflection->isStatic() ? 'staticMethod' : 'method'),
+				);
+			}
+
+			return RestrictedUsage::create(
+				sprintf(
+					"Call to method %s() of deprecated trait %s:\n%s",
+					$methodReflection->getName(),
+					$deprecatedDeclaringTrait->getName(),
+					$traitDescription,
+				),
+				sprintf('%s.deprecatedTrait', $methodReflection->isStatic() ? 'staticMethod' : 'method'),
+			);
+		}
+
 		if (!$methodReflection->isDeprecated()->yes()) {
 			return null;
 		}
@@ -111,6 +140,19 @@ class RestrictedDeprecatedMethodUsageExtension implements RestrictedMethodUsageE
 			),
 			sprintf('%s.deprecated', $methodReflection->isStatic() ? 'staticMethod' : 'method'),
 		);
+	}
+
+	private function findDeprecatedDeclaringTrait(ClassReflection $declaringClass, string $methodName): ?ClassReflection
+	{
+		foreach ($declaringClass->getTraits() as $trait) {
+			if (!$trait->hasNativeMethod($methodName) || !$trait->isDeprecated()) {
+				continue;
+			}
+
+			return $trait;
+		}
+
+		return null;
 	}
 
 }

--- a/tests/Rules/Deprecations/CallToDeprecatedMethodRuleTest.php
+++ b/tests/Rules/Deprecations/CallToDeprecatedMethodRuleTest.php
@@ -47,6 +47,14 @@ class CallToDeprecatedMethodRuleTest extends RuleTestCase
 					"Call to deprecated method prophesize() of class CheckDeprecatedMethodCall\\UsingDeprecatedMethodFromTrait:\nUse TraitReplacingDeprecatedMethod::prophesize()",
 					64,
 				],
+				[
+					'Call to method methodFromDeprecatedTrait() of deprecated trait CheckDeprecatedMethodCall\DeprecatedTrait.',
+					79,
+				],
+				[
+					"Call to method methodFromDeprecatedTraitWithDescription() of deprecated trait CheckDeprecatedMethodCall\\DeprecatedTraitWithDescription:\nUse something else.",
+					80,
+				],
 			],
 		);
 	}

--- a/tests/Rules/Deprecations/CallToDeprecatedStaticMethodRuleTest.php
+++ b/tests/Rules/Deprecations/CallToDeprecatedStaticMethodRuleTest.php
@@ -71,6 +71,14 @@ class CallToDeprecatedStaticMethodRuleTest extends RuleTestCase
 					'Call to method doDeprecatedBar() of deprecated class CheckDeprecatedStaticMethodCall\DeprecatedBar.',
 					81,
 				],
+				[
+					'Call to method staticMethodFromDeprecatedTrait() of deprecated trait CheckDeprecatedStaticMethodCall\DeprecatedTrait.',
+					83,
+				],
+				[
+					"Call to method staticMethodFromDeprecatedTraitWithDescription() of deprecated trait CheckDeprecatedStaticMethodCall\\DeprecatedTraitWithDescription:\nUse something else.",
+					84,
+				],
 			],
 		);
 	}

--- a/tests/Rules/Deprecations/data/call-to-deprecated-method-definition.php
+++ b/tests/Rules/Deprecations/data/call-to-deprecated-method-definition.php
@@ -94,3 +94,39 @@ trait TraitReplacingDeprecatedMethod
 	}
 }
 
+/**
+ * @deprecated
+ */
+trait DeprecatedTrait
+{
+
+	public function methodFromDeprecatedTrait(): void
+	{
+	}
+
+	public static function staticMethodFromDeprecatedTrait(): void
+	{
+	}
+
+}
+
+/**
+ * @deprecated Use something else.
+ */
+trait DeprecatedTraitWithDescription
+{
+
+	public function methodFromDeprecatedTraitWithDescription(): void
+	{
+	}
+
+}
+
+class ClassUsingDeprecatedTrait
+{
+
+	use DeprecatedTrait;
+	use DeprecatedTraitWithDescription;
+
+}
+

--- a/tests/Rules/Deprecations/data/call-to-deprecated-method.php
+++ b/tests/Rules/Deprecations/data/call-to-deprecated-method.php
@@ -74,3 +74,17 @@ final class UsingTraitReplacementForDeprecatedMethod extends MethodMovedToTraitC
 		$this->prophesize();
 	}
 }
+
+$obj = new ClassUsingDeprecatedTrait();
+$obj->methodFromDeprecatedTrait();
+$obj->methodFromDeprecatedTraitWithDescription();
+
+/**
+ * @deprecated
+ */
+function deprecated_scope_for_deprecated_trait(): void
+{
+	$obj = new ClassUsingDeprecatedTrait();
+	$obj->methodFromDeprecatedTrait();
+	$obj->methodFromDeprecatedTraitWithDescription();
+}

--- a/tests/Rules/Deprecations/data/call-to-deprecated-static-method-definition.php
+++ b/tests/Rules/Deprecations/data/call-to-deprecated-static-method-definition.php
@@ -66,3 +66,35 @@ class DeprecatedBaz extends Foo
 {
 
 }
+
+/**
+ * @deprecated
+ */
+trait DeprecatedTrait
+{
+
+	public static function staticMethodFromDeprecatedTrait(): void
+	{
+	}
+
+}
+
+/**
+ * @deprecated Use something else.
+ */
+trait DeprecatedTraitWithDescription
+{
+
+	public static function staticMethodFromDeprecatedTraitWithDescription(): void
+	{
+	}
+
+}
+
+class ClassUsingDeprecatedTrait
+{
+
+	use DeprecatedTrait;
+	use DeprecatedTraitWithDescription;
+
+}

--- a/tests/Rules/Deprecations/data/call-to-deprecated-static-method.php
+++ b/tests/Rules/Deprecations/data/call-to-deprecated-static-method.php
@@ -79,3 +79,15 @@ class Child extends Foo
 }
 
 DeprecatedBar::doDeprecatedBar();
+
+ClassUsingDeprecatedTrait::staticMethodFromDeprecatedTrait();
+ClassUsingDeprecatedTrait::staticMethodFromDeprecatedTraitWithDescription();
+
+/**
+ * @deprecated
+ */
+function deprecated_scope_for_deprecated_trait(): void
+{
+	ClassUsingDeprecatedTrait::staticMethodFromDeprecatedTrait();
+	ClassUsingDeprecatedTrait::staticMethodFromDeprecatedTraitWithDescription();
+}


### PR DESCRIPTION
Closes #128

When a trait is marked `@deprecated`, calls to its methods are now reported as deprecation errors — for both instance and static calls.

Example:
```php
/** @deprecated use something else */
trait MyTrait {
    public function doFoo() {}
}

class X {
    use MyTrait;
}

$x = new X();
$x->doFoo(); // Call to method doFoo() of deprecated trait MyTrait: use something else
```