### PR TITLE
Include constant name in deprecation message when a description exists

### DIFF
--- a/src/Rules/Deprecations/FetchingDeprecatedConstRule.php
+++ b/src/Rules/Deprecations/FetchingDeprecatedConstRule.php
@@ -43,16 +43,27 @@ class FetchingDeprecatedConstRule implements Rule
 
 		$constantReflection = $this->reflectionProvider->getConstant($node->name, $scope);
 
-		if ($constantReflection->isDeprecated()->yes()) {
+		if (!$constantReflection->isDeprecated()->yes()) {
+			return [];
+		}
+
+		$description = $constantReflection->getDeprecatedDescription();
+		if ($description === null) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					$constantReflection->getDeprecatedDescription() ?? 'Use of constant %s is deprecated.',
+					'Use of constant %s is deprecated.',
 					$constantReflection->getName(),
 				))->identifier('constant.deprecated')->build(),
 			];
 		}
 
-		return [];
+		return [
+			RuleErrorBuilder::message(sprintf(
+				"Use of constant %s is deprecated:\n%s",
+				$constantReflection->getName(),
+				$description,
+			))->identifier('constant.deprecated')->build(),
+		];
 	}
 
 }

--- a/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
+++ b/tests/Rules/Deprecations/FetchingDeprecatedConstRuleTest.php
@@ -60,6 +60,24 @@ class FetchingDeprecatedConstRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testFetchingDeprecatedConstWithDescription(): void
+	{
+		require_once __DIR__ . '/data/fetching-deprecated-const-with-description-definition.php';
+		$this->analyse(
+			[__DIR__ . '/data/fetching-deprecated-const-with-description.php'],
+			[
+				[
+					"Use of constant FetchingDeprecatedConstWithDescription\\DEPRECATED_WITH_DESCRIPTION is deprecated:\nin 1.2.0 and is removed from 2.0.0. Use SomeClass::NEW_ONE instead.",
+					5,
+				],
+				[
+					"Use of constant FetchingDeprecatedConstWithDescription\\DEPRECATED_WITH_DESCRIPTION is deprecated:\nin 1.2.0 and is removed from 2.0.0. Use SomeClass::NEW_ONE instead.",
+					6,
+				],
+			],
+		);
+	}
+
 	public function testEstrictWithVersionGuard(): void
 	{
 		$errors = [];

--- a/tests/Rules/Deprecations/data/fetching-deprecated-const-with-description-definition.php
+++ b/tests/Rules/Deprecations/data/fetching-deprecated-const-with-description-definition.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FetchingDeprecatedConstWithDescription;
+
+/**
+ * @deprecated in 1.2.0 and is removed from 2.0.0. Use SomeClass::NEW_ONE instead.
+ */
+const DEPRECATED_WITH_DESCRIPTION = 'foo';

--- a/tests/Rules/Deprecations/data/fetching-deprecated-const-with-description.php
+++ b/tests/Rules/Deprecations/data/fetching-deprecated-const-with-description.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace FetchingDeprecatedConstWithDescription;
+
+DEPRECATED_WITH_DESCRIPTION;
+\FetchingDeprecatedConstWithDescription\DEPRECATED_WITH_DESCRIPTION;


### PR DESCRIPTION
`FetchingDeprecatedConstRule` passes the deprecation description to `sprintf()` as the format string:

```php
RuleErrorBuilder::message(sprintf(
    $constantReflection->getDeprecatedDescription() ?? 'Use of constant %s is deprecated.',
    $constantReflection->getName(),
))
```

The `%s` placeholder for the constant name only exists in the fallback message, so any constant documented with `@deprecated` text reports the description alone. Analyzing Drupal code that uses `REQUIREMENT_ERROR` produces:

```
in drupal:11.2.0 and is removed from drupal:12.0.0. Use \Drupal\Core\Extension\Requirement\RequirementSeverity::Error instead.
```

There is no way to tell which constant triggered it, which is a problem when a single line fetches several deprecated constants.

This formats the message the way the other deprecation checks do (`RestrictedDeprecatedFunctionUsageExtension`, `RestrictedDeprecatedClassConstantUsageExtension`) — name first, description on the next line:

```
Use of constant REQUIREMENT_ERROR is deprecated:
in drupal:11.2.0 and is removed from drupal:12.0.0. Use \Drupal\Core\Extension\Requirement\RequirementSeverity::Error instead.
```

Messages for constants without a description are unchanged. Added a test covering the described case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)